### PR TITLE
Media as a dynamic property

### DIFF
--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -214,7 +214,9 @@ class Select2Mixin(object):
         if RENDER_SELECT2_STATICS:
             return forms.Media(
                 js=get_select2_js_libs(),
-                css=get_select2_css_libs(light=True))
+                css={
+                    'screen': get_select2_css_libs(light=True)
+                })
         return forms.Media()
     media = property(_media)
 
@@ -486,7 +488,9 @@ class HeavySelect2Mixin(Select2Mixin):
         if RENDER_SELECT2_STATICS:
             return forms.Media(
                 js=get_select2_js_libs(),
-                css=get_select2_css_libs())
+                css={
+                    'screen': get_select2_css_libs()
+                })
         return forms.Media()
     media = property(_media)
 

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -214,7 +214,7 @@ class Select2Mixin(object):
         if RENDER_SELECT2_STATICS:
             return forms.Media(
                 js=get_select2_js_libs(),
-                css=get_select2_css_libs(light=True)
+                css=get_select2_css_libs(light=True))
         return forms.Media()
     media = property(_media)
 
@@ -486,7 +486,7 @@ class HeavySelect2Mixin(Select2Mixin):
         if RENDER_SELECT2_STATICS:
             return forms.Media(
                 js=get_select2_js_libs(),
-                css=get_select2_css_libs()
+                css=get_select2_css_libs())
         return forms.Media()
     media = property(_media)
 

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -216,7 +216,7 @@ class Select2Mixin(object):
             media._js = get_select2_js_libs()
             media._css['screen'] = get_select2_css_libs(light=True)
         return media
-    media = property(_media)
+    media = property(_get_media)
 
 
 class Select2Widget(Select2Mixin, forms.Select):
@@ -488,7 +488,7 @@ class HeavySelect2Mixin(Select2Mixin):
             media._js = get_select2_heavy_js_libs()
             media._css['screen'] = get_select2_css_libs()
         return media
-    media = property(_media)
+    media = property(_get_media)
 
 
 class HeavySelect2Widget(HeavySelect2Mixin, forms.TextInput):

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -211,11 +211,11 @@ class Select2Mixin(object):
         return mark_safe(s)
 
     def _media(self):
-        media = forms.Media()
         if RENDER_SELECT2_STATICS:
-            media._js = get_select2_js_libs()
-            media._css = get_select2_css_libs(light=True)
-        return media
+            return forms.Media(
+                js=get_select2_js_libs(),
+                css=get_select2_css_libs(light=True)
+        return forms.Media()
     media = property(_media)
 
 
@@ -483,11 +483,11 @@ class HeavySelect2Mixin(Select2Mixin):
         return js
 
     def _media(self):
-        media = forms.Media()
         if RENDER_SELECT2_STATICS:
-            media._js = get_select2_js_libs()
-            media._css = get_select2_css_libs()
-        return media
+            return forms.Media(
+                js=get_select2_js_libs(),
+                css=get_select2_css_libs()
+        return forms.Media()
     media = property(_media)
 
 

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -210,14 +210,12 @@ class Select2Mixin(object):
 
         return mark_safe(s)
 
-    def _media(self):
+    def _get_media(self):
+        media = forms.Media()
         if RENDER_SELECT2_STATICS:
-            return forms.Media(
-                js=get_select2_js_libs(),
-                css={
-                    'screen': get_select2_css_libs(light=True)
-                })
-        return forms.Media()
+            media._js = get_select2_js_libs()
+            media._css['screen'] = get_select2_css_libs(light=True)
+        return media
     media = property(_media)
 
 
@@ -484,14 +482,12 @@ class HeavySelect2Mixin(Select2Mixin):
         js += super(HeavySelect2Mixin, self).render_inner_js_code(id_, name, value, attrs, choices, *args)
         return js
 
-    def _media(self):
+    def _get_media(self):
+        media = forms.Media()
         if RENDER_SELECT2_STATICS:
-            return forms.Media(
-                js=get_select2_js_libs(),
-                css={
-                    'screen': get_select2_css_libs()
-                })
-        return forms.Media()
+            media._js = get_select2_js_libs()
+            media._css['screen'] = get_select2_css_libs()
+        return media
     media = property(_media)
 
 

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -211,11 +211,21 @@ class Select2Mixin(object):
         return mark_safe(s)
 
     def _get_media(self):
-        media = forms.Media()
+        """
+        Construct Media as a dynamic property
+
+        This is essential because we need to check RENDER_SELECT2_STATICS
+        before returning our assets.
+        
+        for more information:
+        https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property        
+        """
         if RENDER_SELECT2_STATICS:
-            media._js = get_select2_js_libs()
-            media._css['screen'] = get_select2_css_libs(light=True)
-        return media
+            return forms.Media(
+                js=get_select2_js_libs(),
+                css={'screen': get_select2_css_libs(light=True)}
+            )
+        return forms.Media()
     media = property(_get_media)
 
 
@@ -483,11 +493,21 @@ class HeavySelect2Mixin(Select2Mixin):
         return js
 
     def _get_media(self):
-        media = forms.Media()
+        """
+        Construct Media as a dynamic property
+
+        This is essential because we need to check RENDER_SELECT2_STATICS
+        before returning our assets.
+        
+        for more information:
+        https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
+        """
         if RENDER_SELECT2_STATICS:
-            media._js = get_select2_heavy_js_libs()
-            media._css['screen'] = get_select2_css_libs()
-        return media
+            return forms.Media(
+                js=get_select2_heavy_js_libs(),
+                css={'screen': get_select2_css_libs()}
+            )
+        return forms.Media()
     media = property(_get_media)
 
 

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -216,7 +216,7 @@ class Select2Mixin(object):
 
         This is essential because we need to check RENDER_SELECT2_STATICS
         before returning our assets.
-        
+
         for more information:
         https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property        
         """
@@ -498,7 +498,7 @@ class HeavySelect2Mixin(Select2Mixin):
 
         This is essential because we need to check RENDER_SELECT2_STATICS
         before returning our assets.
-        
+
         for more information:
         https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -485,7 +485,7 @@ class HeavySelect2Mixin(Select2Mixin):
     def _get_media(self):
         media = forms.Media()
         if RENDER_SELECT2_STATICS:
-            media._js = get_select2_js_libs()
+            media._js = get_select2_heavy_js_libs()
             media._css['screen'] = get_select2_css_libs()
         return media
     media = property(_media)

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -210,12 +210,13 @@ class Select2Mixin(object):
 
         return mark_safe(s)
 
-    class Media:
+    def _media(self):
+        media = Media()
         if RENDER_SELECT2_STATICS:
-            js = get_select2_js_libs()
-            css = {
-                'screen': get_select2_css_libs(light=True),
-            }
+            media._js = get_select2_js_libs()
+            media._css = get_select2_css_libs(light=True)
+        return media
+    media = property(_media)
 
 
 class Select2Widget(Select2Mixin, forms.Select):
@@ -481,12 +482,13 @@ class HeavySelect2Mixin(Select2Mixin):
         js += super(HeavySelect2Mixin, self).render_inner_js_code(id_, name, value, attrs, choices, *args)
         return js
 
-    class Media:
+    def _media(self):
+        media = Media()
         if RENDER_SELECT2_STATICS:
-            js = get_select2_heavy_js_libs()
-            css = {
-                'screen': get_select2_css_libs()
-            }
+            media._js = get_select2_js_libs()
+            media._css = get_select2_css_libs()
+        return media
+    media = property(_media)
 
 
 class HeavySelect2Widget(HeavySelect2Mixin, forms.TextInput):

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -211,7 +211,7 @@ class Select2Mixin(object):
         return mark_safe(s)
 
     def _media(self):
-        media = Media()
+        media = forms.Media()
         if RENDER_SELECT2_STATICS:
             media._js = get_select2_js_libs()
             media._css = get_select2_css_libs(light=True)
@@ -483,7 +483,7 @@ class HeavySelect2Mixin(Select2Mixin):
         return js
 
     def _media(self):
-        media = Media()
+        media = forms.Media()
         if RENDER_SELECT2_STATICS:
             media._js = get_select2_js_libs()
             media._css = get_select2_css_libs()

--- a/django_select2/widgets.py
+++ b/django_select2/widgets.py
@@ -218,7 +218,7 @@ class Select2Mixin(object):
         before returning our assets.
 
         for more information:
-        https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property        
+        https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property
         """
         if RENDER_SELECT2_STATICS:
             return forms.Media(


### PR DESCRIPTION
**Symptoms:**
While using AutoModelSelect2Field in admin site, I noticed that css files are rendered only at the first request to the add or edit forms, after that the widget is rendered but without loading any css files from get_select2_css_libs.

**Solution:**
I changed assets loading from [Assets as a static definition](https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property) to [Media as a dynamic property](https://docs.djangoproject.com/en/1.8/topics/forms/media/#media-as-a-dynamic-property) as described at Django docs.
